### PR TITLE
20160603 133000 control commands support

### DIFF
--- a/apollo/command_processor_component.py
+++ b/apollo/command_processor_component.py
@@ -3,6 +3,7 @@
 import asyncio
 import logging
 import multiprocessing
+import queue
 
 from autobahn.asyncio import wamp
 
@@ -30,12 +31,33 @@ class CommandProcessorComponent(wamp.ApplicationSession):
             raise Exception('A control_queue must be set in self.config.extra')
 
         while True:
-            id, msg = yield from utils.coro_queue_get(command_queue)
+            cnt_msg = yield from utils.coro_queue_get(control_queue)
+
+            if cnt_msg == 'pause':
+                while True:
+                    cnt_msg = yield from utils.coro_queue_get(control_queue)
+                    if cnt_msg == 'resume':
+                        break
+                    yield from asyncio.sleep(0.1)
+
+            elif cnt_msg == 'erase':
+                utils.flush_queue(command_queue)
+                continue
+
+            elif cnt_msg == 'resume':
+                pass
+
+            else:
+                logger.error('Received unknown control message: {}'.format(cnt_msg))
+                break
+
+            cmd_pkt = yield from utils.coro_queue_get(command_queue)
+            pkt_id = cmd_pkt.get('id', 'ID NOT FOUND')
 
             # TODO: execute roboto message and publish result
 
-            logger.debug('Dequeued Message ID: {} with {}'.format(id, msg))
-            self.publish(Config.ROBOT_TO_BROWSER_TOPIC, msg)
+            logger.debug('Dequeued Message ID: {} with {}'.format(pkt_id, cmd_pkt))
+            self.publish(Config.ROBOT_TO_BROWSER_TOPIC, cmd_pkt)
 
 
 if __name__ == '__main__':
@@ -48,11 +70,15 @@ if __name__ == '__main__':
     )
 
     command_queue = multiprocessing.Manager().Queue(50)
+    control_queue = multiprocessing.Manager().Queue(50)
 
     print(type(command_queue))
 
     runner = wamp.ApplicationRunner(
         url, realm='ot_realm',
-        extra={'command_queue': command_queue}
+        extra={
+            'command_queue': command_queue,
+            'control_queue': control_queue
+        }
     )
     runner.run(CommandProcessorComponent)

--- a/apollo/command_processor_component.py
+++ b/apollo/command_processor_component.py
@@ -31,6 +31,15 @@ class CommandProcessorComponent(wamp.ApplicationSession):
 
     @asyncio.coroutine
     def onJoin(self, details):
+        """
+        :param details:
+        :return:
+
+        Listens to control commands from control_queue
+        Listens to command commands from command_queue.
+
+        control_queue packets take priority in hanlding over command_queue packets
+        """
         logger.info('CommandProcessorComponent joined')
 
         command_queue = self.config.extra.get('command_queue')
@@ -76,7 +85,7 @@ class CommandProcessorComponent(wamp.ApplicationSession):
 
             pkt_id = cmd_pkt.get('id', 'NA')
 
-            # TODO: execute roboto message and publish result
+            # TODO: execute robo message and publish result
 
             logger.debug('Dequeued Message ID: {} with {}'.format(pkt_id, cmd_pkt))
             self.publish(Config.ROBOT_TO_BROWSER_TOPIC, cmd_pkt)

--- a/apollo/command_processor_component.py
+++ b/apollo/command_processor_component.py
@@ -21,9 +21,13 @@ class CommandProcessorComponent(wamp.ApplicationSession):
         logger.info('CommandProcessorComponent joined')
 
         command_queue = self.config.extra.get('command_queue')
+        control_queue = self.config.extra.get('control_queue')
 
         if not command_queue:
             raise Exception('A command_queue must be set in self.config.extra')
+
+        if not control_queue:
+            raise Exception('A control_queue must be set in self.config.extra')
 
         while True:
             id, msg = yield from utils.coro_queue_get(command_queue)

--- a/apollo/command_receiver_component.py
+++ b/apollo/command_receiver_component.py
@@ -11,7 +11,17 @@ from config.settings import Config
 logger = logging.getLogger('command-receiver-component')
 
 
-def enqueue_message(command_queue, control_queue, message):
+def message_queue_router(command_queue, control_queue, message):
+    """
+    :param command_queue: multiprocessing.Queue
+    :param control_queue: multiprocessing.Queue
+    :param message: dict
+    :return:
+
+    Given a message (dict), this method adds the given message to either the
+    command_queue or control_queue based on the type property of the message
+    """
+
     CONTROL_PACKET_TYPES = ['pause', 'resume', 'erase']
 
     pkt_type = message.get('type', {})
@@ -41,7 +51,7 @@ class CommandReceiverComponent(wamp.ApplicationSession):
         if not command_queue:
             raise Exception('A control_queue must be set in self.config.extra')
 
-        handle_message = partial(enqueue_message, command_queue, control_queue)
+        handle_message = partial(message_queue_router, command_queue, control_queue)
         yield from self.subscribe(handle_message, Config.BROWSER_TO_ROBOT_TOPIC)
 
 

--- a/apollo/utils.py
+++ b/apollo/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+import queue
 import socket
 
 
@@ -12,7 +13,17 @@ def get_free_os_address():
 
 
 @asyncio.coroutine
-def coro_queue_get(queue, loop=None):
+def coro_queue_get(q, loop=None):
     loop = loop or asyncio.get_event_loop()
-    return (yield from loop.run_in_executor(ThreadPoolExecutor(1), queue.get))
+    return (yield from loop.run_in_executor(ThreadPoolExecutor(1), q.get))
+
+def flush_queue(q):
+    items_cnt = q.qsize()
+
+    while items_cnt > 0:
+        try:
+            q.get_nowait()
+            items_cnt -= 1
+        except queue.Empty:
+            break
 

--- a/bin/apollo-start
+++ b/bin/apollo-start
@@ -10,7 +10,7 @@ from apollo.command_processor_component import CommandProcessorComponent
 from apollo.command_receiver_component import CommandReceiverComponent
 
 
-def start_command_processor(command_queue, url, realm, loop=None):
+def start_command_processor(command_queue, control_queue, url, realm, loop=None):
     # New event loops are required for event loops to run in a subprocess
     loop = loop or asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -18,12 +18,15 @@ def start_command_processor(command_queue, url, realm, loop=None):
     runner = wamp.ApplicationRunner(
         url,
         realm=realm,
-        extra={'command_queue': command_queue}
+        extra={
+            'command_queue': command_queue,
+            'control_queue': control_queue
+        }
     )
     runner.run(CommandProcessorComponent)
 
 
-def start_command_receiver(command_queue, url, realm, loop=None):
+def start_command_receiver(command_queue, control_queue, url, realm, loop=None):
     # New event loops are required for event loops to run in a subprocess
     loop = loop or asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
@@ -31,7 +34,10 @@ def start_command_receiver(command_queue, url, realm, loop=None):
     runner = wamp.ApplicationRunner(
         url,
         realm=realm,
-        extra={'command_queue': command_queue}
+        extra={
+            'command_queue': command_queue,
+            'control_queue': control_queue
+        }
     )
     runner.run(CommandReceiverComponent)
 

--- a/bin/apollo-start
+++ b/bin/apollo-start
@@ -43,14 +43,15 @@ def start_command_receiver(command_queue, control_queue, url, realm, loop=None):
 
 
 command_queue = multiprocessing.Manager().Queue(Config.COMMAND_QUEUE_SIZE)
+control_queue = multiprocessing.Manager().Queue(Config.COMMAND_QUEUE_SIZE)
 
 processor_process = multiprocessing.Process(
     target=start_command_processor,
-    args=(command_queue, Config.ROUTER_URL, Config.ROUTER_REALM)
+    args=(command_queue, control_queue, Config.ROUTER_URL, Config.ROUTER_REALM)
 )
 receiver_process = multiprocessing.Process(
     target=start_command_receiver,
-    args=(command_queue, Config.ROUTER_URL, Config.ROUTER_REALM)
+    args=(command_queue, control_queue, Config.ROUTER_URL, Config.ROUTER_REALM)
 )
 
 

--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -9,8 +9,6 @@ from apollo.command_processor_component import (
     CommandProcessorComponent
 )
 
-from apollo import utils
-
 
 class CommandProcessorComponentTestCase(unittest.TestCase):
 

--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -14,12 +14,17 @@ from apollo import utils
 
 class CommandProcessorComponentTestCase(unittest.TestCase):
 
-    def test_command_procc_publishes_on_joining(self):
+    def test_command_processor_publishes_on_joining(self):
         command_queue = multiprocessing.Manager().Queue()
+        control_queue = multiprocessing.Manager().Queue()
+
         command_queue.put_nowait({})
         command_queue.put_nowait(None)
 
-        config = ComponentConfig(extra={'command_queue': command_queue})
+        config = ComponentConfig(extra={
+            'command_queue': command_queue,
+            'control_queue': control_queue
+        })
         comp = CommandProcessorComponent(config)
         comp._transport = mock.Mock()
 

--- a/tests/test_command_processor.py
+++ b/tests/test_command_processor.py
@@ -14,24 +14,43 @@ from apollo import utils
 
 class CommandProcessorComponentTestCase(unittest.TestCase):
 
-    def test_command_processor_publishes_on_joining(self):
-        command_queue = multiprocessing.Manager().Queue()
-        control_queue = multiprocessing.Manager().Queue()
-
-        command_queue.put_nowait({})
-        command_queue.put_nowait(None)
+    def setUp(self):
+        self.command_queue = multiprocessing.Manager().Queue()
+        self.control_queue = multiprocessing.Manager().Queue()
 
         config = ComponentConfig(extra={
-            'command_queue': command_queue,
-            'control_queue': control_queue
+            'command_queue': self.command_queue,
+            'control_queue': self.control_queue
         })
-        comp = CommandProcessorComponent(config)
-        comp._transport = mock.Mock()
+        self.comp = CommandProcessorComponent(config)
+        self.comp._transport = mock.Mock()
 
-        comp.publish = mock.Mock()
+
+    def test_command_processor_publishes_on_joining(self):
+        self.command_queue.put_nowait({})
+        self.command_queue.put_nowait(None)
+
+        self.comp.publish = mock.Mock()
 
         loop = asyncio.new_event_loop()
         asyncio.set_event_loop(loop)
-        loop.run_until_complete(comp.onJoin(None))
+        loop.run_until_complete(self.comp.onJoin(None))
 
-        self.assertTrue(comp.publish.called)
+        self.assertTrue(self.comp.publish.called)
+
+
+    def test_command_processor_pauses_and_resumes(self):
+        self.control_queue.put_nowait({'type': 'pause'})
+        self.control_queue.put_nowait({'type': 'resume'})
+        self.command_queue.put_nowait(None)
+
+        self.comp.publish = mock.Mock()
+        self.comp.on_pause = mock.Mock()
+        self.comp.on_resume = mock.Mock()
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.run_until_complete(self.comp.onJoin(None))
+
+        self.assertTrue(self.comp.on_pause.called)
+        self.assertTrue(self.comp.on_resume.called)

--- a/tests/test_command_receiver.py
+++ b/tests/test_command_receiver.py
@@ -14,16 +14,23 @@ from apollo import utils
 
 
 class CommandReceiverComponentTestCase(unittest.TestCase):
-    def test_enqueue_message(self):
-        qq = multiprocessing.Manager().Queue()
+    def test_message_queue_router(self):
+        cmd_q = multiprocessing.Manager().Queue()
+        cnt_q = multiprocessing.Manager().Queue()
 
-        msg_input = {'type': 'msg'}
-        message_queue_router(qq, msg_input)
+        pause_msg = {'type': 'pause'}
+        resume_msg = {'type': 'resume'}
+        data_msg = {'type': 'foo'}
+        erase_msg = {'type': 'erase'}
 
-        idx, msg_output = qq.get_nowait()
+        message_queue_router(cmd_q, cnt_q, data_msg)
+        message_queue_router(cmd_q, cnt_q, pause_msg)
+        message_queue_router(cmd_q, cnt_q, data_msg)
+        message_queue_router(cmd_q, cnt_q, resume_msg)
+        message_queue_router(cmd_q, cnt_q, erase_msg)
 
-        self.assertEqual(msg_input, msg_output)
-        self.assertTrue(isinstance(idx, str))
+        self.assertEqual(cmd_q.qsize(), 2)
+        self.assertEqual(cnt_q.qsize(), 3)
 
 
     def test_command_recv_subscribes_on_joining(self):

--- a/tests/test_command_receiver.py
+++ b/tests/test_command_receiver.py
@@ -6,7 +6,7 @@ from unittest import mock
 from autobahn.wamp.types import ComponentConfig
 
 from apollo.command_receiver_component import (
-    enqueue_message,
+    message_queue_router,
     CommandReceiverComponent
 )
 
@@ -18,7 +18,7 @@ class CommandReceiverComponentTestCase(unittest.TestCase):
         qq = multiprocessing.Manager().Queue()
 
         msg_input = {'type': 'msg'}
-        enqueue_message(qq, msg_input)
+        message_queue_router(qq, msg_input)
 
         idx, msg_output = qq.get_nowait()
 


### PR DESCRIPTION
This pull requests enables the Motor Driver server (or apollo as it's called now) to handle to control commands.

The server runs with 2 different queues,
- a control queue
- a command queue

The control queue contains packets for controlling whether the server `pauses`, `resumes`, or `erases` robot command messages. There are 2 separate queues because if the command queue is flooded with a backlog of robot commands then control commands will not drown in this backlog and instead get processed in their own higher priority.
